### PR TITLE
Return relative paths of modules as object keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ require('./scripts/*.js', {glob: true});
 var hash = require('./scripts/*.js', {hash: true});
 
 var hashWithExtensions = require('./scripts/*.js', {hash: true, ext: true});
+
+var hashWithPaths = require('./**/*.js', {hash: 'path'});
+
+var hashWithExtensionsAndPaths = require('./**/*.js', {hash: 'path', ext: true});
 ```
 
 which is then transformed into the following if the folder './scripts/' contains the files 'abc.js' and 'def.js'
@@ -37,6 +41,10 @@ require('./scripts/def.js');
 var hash = {"abc": require('./scripts/abc.js'),"def": require('./scripts/def.js')};
 
 var hashWithExtensions = {"abc.js": require('./scripts/abc.js'),"def.js": require('./scripts/def.js')};
+
+var hashWithPaths = {"./scripts/abc": require('./scripts/abc.js'),"./scripts/def": require('./scripts/def.js')};
+
+var hashWithExtensionsAndPaths = {"./scripts/abc.js": require('./scripts/abc.js'),"./scripts/def.js": require('./scripts/def.js')};
 ```
 
 Transform will generate classic require() calls before browserify is run.

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 var transformTools = require('browserify-transform-tools');
 var glob = require('glob');
 var path = require('path');
+var fs = require('fs');
 
 module.exports = transformTools.makeRequireTransform('require-globify', {
     jsFilesOnly: true,
@@ -17,16 +18,24 @@ module.exports = transformTools.makeRequireTransform('require-globify', {
       if (files.length !== 0 && files.length > 0) {
         var modules = [];
         var replacement;
+        var filePath;
         for (var fi = 0, fl = files.length; fi < fl; fi++) {
-          if (path.resolve(cwd, files[fi]) !== opts.file) {
+          filePath = path.resolve(cwd, files[fi]);
+          if (filePath !== opts.file && !fs.statSync(filePath).isDirectory()) {
             modules.push(files[fi]);
           }
         }
         if ((typeof optsObj.hash !== "undefined" && optsObj.hash !== null && optsObj.hash !== false)) {
+          var hashKey, modulePath;
           for (var mi = 0, mil = modules.length; mi < mil; mi++) {
             var mod = modules[mi];
-            var hashKey = optsObj.ext ? path.basename(mod) : path.basename(mod, path.extname(mod));
-            var modulePath = path.dirname(mod) + '/' + hashKey;
+            if (optsObj.hash === 'path') {
+              hashKey = optsObj.ext ? mod : mod.slice(0, mod.lastIndexOf(path.extname(mod)));
+              modulePath = hashKey;
+            } else if (optsObj.hash === true) {
+              hashKey = optsObj.ext ? path.basename(mod) : path.basename(mod, path.extname(mod));
+              modulePath = path.dirname(mod) + '/' + hashKey;
+            }
             modules[mi] = '"' + hashKey + '": require("' + modulePath + '")';
           }
           replacement = '{' + modules.join(', ') + '}';

--- a/spec/hash-recursive.js
+++ b/spec/hash-recursive.js
@@ -1,0 +1,61 @@
+var fs = require('fs');
+var browserify = require('browserify');
+var through = require('through2');
+var globRequireTransform = require('./../index');
+var transformTools = require('browserify-transform-tools');
+
+describe('hash recursive glob replacement', function() {
+	it('should include the relative paths of files if the configuration is set so', function(done) {
+		var data = '';
+		browserify({
+			entries: require.resolve('./hash-recursive/path-dont-include-exts/module.js')
+		}).transform(globRequireTransform).bundle().pipe(through(function(buf, enc, cb) {
+			data += buf;
+			cb();
+		}, function(cb) {
+			var err;
+			if (data.indexOf('"./1": require("./1")') === -1) {
+				err = new Error('expected relative path to be included in "./1":');
+			}
+			if (data.indexOf('"./2": require("./2")') === -1) {
+				err = new Error('expected relative path to be included in "./2":');
+			}
+			if (data.indexOf('"./3/3": require("./3/3")') === -1) {
+				err = new Error('expected relative path to be included in "./3/3":');
+			}
+			if (data.indexOf('"./4/4/4/4": require("./4/4/4/4")') === -1) {
+				err = new Error('expected relative path to be included in "./4/4/4/4":');
+			}
+
+			cb();
+			done(err);
+		}));
+	});
+
+	it('should include the relative paths and extensions of files if the configuration is set so', function(done) {
+		var data = '';
+		browserify({
+			entries: require.resolve('./hash-recursive/path-include-exts/module.js')
+		}).transform(globRequireTransform).bundle().pipe(through(function(buf, enc, cb) {
+			data += buf;
+			cb();
+		}, function(cb) {
+			var err;
+			if (data.indexOf('"./1.js": require("./1.js")') === -1) {
+				err = new Error('expected relative path to be included in "./1.js":');
+			}
+			if (data.indexOf('"./2.js": require("./2.js")') === -1) {
+				err = new Error('expected relative path to be included in "./2.js":');
+			}
+			if (data.indexOf('"./3/3.js": require("./3/3.js")') === -1) {
+				err = new Error('expected relative path to be included in "./3/3.js":');
+			}
+			if (data.indexOf('"./4/4/4/4.js": require("./4/4/4/4.js")') === -1) {
+				err = new Error('expected relative path to be included in "./4/4/4/4.js":');
+			}
+
+			cb();
+			done(err);
+		}));
+	});
+});

--- a/spec/hash-recursive/path-dont-include-exts/1.js
+++ b/spec/hash-recursive/path-dont-include-exts/1.js
@@ -1,0 +1,1 @@
+console.log("test token1");

--- a/spec/hash-recursive/path-dont-include-exts/2.js
+++ b/spec/hash-recursive/path-dont-include-exts/2.js
@@ -1,0 +1,1 @@
+console.log("test token2");

--- a/spec/hash-recursive/path-dont-include-exts/3/3.js
+++ b/spec/hash-recursive/path-dont-include-exts/3/3.js
@@ -1,0 +1,1 @@
+console.log("test token3");

--- a/spec/hash-recursive/path-dont-include-exts/4/4/4/4.js
+++ b/spec/hash-recursive/path-dont-include-exts/4/4/4/4.js
@@ -1,0 +1,1 @@
+console.log("test token4");

--- a/spec/hash-recursive/path-dont-include-exts/module.js
+++ b/spec/hash-recursive/path-dont-include-exts/module.js
@@ -1,0 +1,1 @@
+var rec = require('./**', {hash: 'path'});

--- a/spec/hash-recursive/path-include-exts/1.js
+++ b/spec/hash-recursive/path-include-exts/1.js
@@ -1,0 +1,1 @@
+console.log("test token1");

--- a/spec/hash-recursive/path-include-exts/2.js
+++ b/spec/hash-recursive/path-include-exts/2.js
@@ -1,0 +1,1 @@
+console.log("test token2");

--- a/spec/hash-recursive/path-include-exts/3/3.js
+++ b/spec/hash-recursive/path-include-exts/3/3.js
@@ -1,0 +1,1 @@
+console.log("test token3");

--- a/spec/hash-recursive/path-include-exts/4/4/4/4.js
+++ b/spec/hash-recursive/path-include-exts/4/4/4/4.js
@@ -1,0 +1,1 @@
+console.log("test token4");

--- a/spec/hash-recursive/path-include-exts/module.js
+++ b/spec/hash-recursive/path-include-exts/module.js
@@ -1,0 +1,1 @@
+var rec = require('./**', {hash: 'path', ext: true});


### PR DESCRIPTION
Implemented new option to allow relative paths to be returned as object keys to modules found within a recursive glob expression. If directories are encountered during a recursive find, they are ignored.