### PR TITLE
add customizable sort order, skip and limit options on match list

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,15 @@ The second parameter to require must be an object and supports the following key
 ### options *[optional, default:{}]*
   This allows options to be provided to [node-glob](https://www.npmjs.com/package/glob), which is used internally to find matching files.
 
+### sort *[optional, default: alphanumeric]*
+  By default the list of files returned is sorted by name.  This option allows a custom sort function to be used.  The parameter is passed to sort(), so any of the sort variations supported by sort() can be used.
+
+### skip *[optional, default: 0]*
+  Allows entries at the beginning of the matching list of file names to be skipped.
+
+### limit *[optional, default: length of list]*
+  Allows the list of matching files to be truncated to the specified length.
+
 ### ext *[deprecated, optional, default:false]*
   This option is replaced by `resolve: 'strip-ext'`, but remains supported until version 2.0.0.
   **WARNING**: Backwards compatibility is not available in combination with the newer "resolve" option.

--- a/index.js
+++ b/index.js
@@ -98,7 +98,9 @@ module.exports = require('browserify-transform-tools').makeRequireTransform(
 
       try {
         // sort files to ensure consistent order upon multiple runs
-        files.sort();
+        files.sort(config.sort); //allow custom sorting
+	if (config.skip) files.splice(0, config.skip); //skip files at front
+	if (config.limit) files.splice(config.limit, files.length); //truncate list
 
         result = mode(opts.file, files, config);
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "require-globify",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "transform for browserify, which allows to require files with globbing expressions",
   "main": "./index.js",
   "scripts": {


### PR DESCRIPTION
Added a few features:
- allow custom sort order to be specified (anything that JavaScript sort accepts)
- allow entries at start of match list to be skipped
- allow match list to be truncated