### PR TITLE
Support for a custom mode w/template string replacement

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,8 @@ var fs = require('fs');
 var modes = {
   'expand': require('./modes/expand'),
   'hash': require('./modes/hash'),
-  'list': require('./modes/list')
+  'list': require('./modes/list'),
+  'custom': require('./modes/custom')
 };
 
 module.exports = require('browserify-transform-tools').makeRequireTransform(

--- a/modes/custom.js
+++ b/modes/custom.js
@@ -1,0 +1,10 @@
+module.exports = function(base, files, config) {
+  if (files.length === 0) {
+    return '';
+  }
+  return files.reduce(
+    function(acc, file, idx, arr) {
+      config.template = config.template.replace(new RegExp('{file}', 'g'), file);
+      return (acc ? acc + ";" : "") + config.template;
+    }, false);
+};

--- a/modes/custom.js
+++ b/modes/custom.js
@@ -4,7 +4,7 @@ module.exports = function(base, files, config) {
   }
   return files.reduce(
     function(acc, file, idx, arr) {
-      config.template = config.template.replace(new RegExp('{file}', 'g'), file);
-      return (acc ? acc + ";" : "") + config.template;
+      var template = config.template.replace(new RegExp('{file}', 'g'), file);
+      return (acc ? acc + ";" : "") + template;
     }, false);
 };


### PR DESCRIPTION
Hi capaj,

I wanted a simple reusable way of modifying the expand command by creating a custom mode. This way i can just pass a template parameter into require

```
files = [];
require('./**/*.js', {
  mode: 'custom',
  template: "files['{file}'] = require('{file}')"
})
```

outputs e.g:

```
files['./a.js'] = require('./a.js'); files['./b.js'] = require('./b.js');
```

Let me know if the principle is of interest.
